### PR TITLE
bug/minor: dockerfile: use correct casing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM manulera/shareyourcloningfrontend as frontend
+FROM manulera/shareyourcloningfrontend AS frontend
 
-FROM manulera/shareyourcloningbackend as backend
+FROM manulera/shareyourcloningbackend AS backend
 WORKDIR /home/backend
 COPY --from=frontend /build ./frontend
 COPY ./config.json ./frontend/config.json


### PR DESCRIPTION
This change prevents buildx from generating warnings
![2024-09-26-135417_1206x173_scrot](https://github.com/user-attachments/assets/8120e192-7395-453f-8541-2c80f390238d)

